### PR TITLE
fix(release): reject release PRs from forked repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ jobs:
 
   # The release PR was merged: tag the squash commit, cut a GitHub release
   # from the PR body, and dispatch the publish workflow. The `release/v`
-  # head-ref guard keeps regular feature-PR merges from triggering this.
+  # head-ref guard keeps regular feature-PR merges from triggering this;
+  # the head-repo guard keeps merged fork PRs from triggering it.
   release:
     if: |
       github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.head.ref, 'release/v')
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write       # push the `vX.Y.Z` tag and create the GitHub release

--- a/release/action.yml
+++ b/release/action.yml
@@ -33,6 +33,8 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         PR_MERGED: ${{ github.event.pull_request.merged }}
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        BASE_REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
         if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -45,6 +47,10 @@ runs:
         fi
         if [ "${PR_HEAD_REF#release/v}" = "$PR_HEAD_REF" ]; then
           echo "::error::danielroe/uppt/release expected a 'release/v*' head ref, got '$PR_HEAD_REF'."
+          exit 1
+        fi
+        if [ "$PR_HEAD_REPO" != "$BASE_REPO" ]; then
+          echo "::error::danielroe/uppt/release requires the release PR to originate from this repository (got '$PR_HEAD_REPO', expected '$BASE_REPO'). Add 'github.event.pull_request.head.repo.full_name == github.repository' to the release job's if: condition to skip fork PRs at the workflow level."
           exit 1
         fi
 


### PR DESCRIPTION
closes #12 

> claude wrote everything below based on my instructions except the Actual Changes section which was me

The `release` job fires on `pull_request: closed` events from forks when the head branch matches `release/v*`. Since v0.4.0 fails if `pull_request` trigger is not used, and the readme switched the recommended trigger to `pull_request`, the GitHub Actions token downgrade prevents harm in practice (the tag push 403s), but the failure is opaque to maintainers and depends entirely on GitHub's runtime semantics.

Add an explicit same-repo check in the validate step so:
- Maintainers get a clear, actionable error instead of a generic 403
- The guard survives any future change to GitHub's fork-token behavior (e.g. a repo enabling "Send write tokens to workflows from fork pull requests")

Also update the README workflow example to add the same guard to the job's `if:` condition, so fork merges skip at the workflow level without spinning up a runner. The action check remains as a safety net for users who customize the workflow and drop the condition.

## Actual Changes

If a user adopts the workflow example w/ the edit in this PR to gate on base repo not being a fork, then the release job is skipped.

If for some reason they remove that, or it doesnt make it into the readme example, then the release job will trigger, but will explicitly fail w/ an error message of:

> :error::danielroe/uppt/release requires the release PR to originate from this repository (got '$PR_HEAD_REPO', expected '$BASE_REPO'). Add 'github.event.pull_request.head.repo.full_name == github.repository' to the release job's if: condition to skip fork PRs at the workflow level.

which points them to making a change in their own workflow, to remove the ❌ 