### PR TITLE
docs: document Actions PR creation perms as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ The aim of **uppt** is to make a very simple, secure release workflow for mainta
 2. Create a [GitHub environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) named `npm`. You can scope it to `v*` tags, and configure any restrictions on it (such as requiring approvals if you want).
    ![a screenshot of github environment configuration settings](https://raw.githubusercontent.com/danielroe/uppt/main/assets/trusted-publisher.png)
 
-**3.** Add the following workflow to your repo in `.github/workflows/release.yml`, and you're done!
+**3.** Allow GitHub Actions to create pull requests on your repo: under **Settings → Actions → General → Workflow permissions** (`https://github.com/<user>/<repo>/settings/actions`), check **Allow GitHub Actions to create and approve pull requests**. Without this, `uppt/pr` fails with `403 Forbidden: GitHub Actions is not permitted to create or approve pull requests` when opening the release PR.
+
+**4.** Add the following workflow to your repo in `.github/workflows/release.yml`, and you're done!
 
 ```yaml
 name: release
@@ -126,6 +128,10 @@ This subaction runs `pnpm pack` (if you have a `pnpm-lock.yaml`) and then runs `
 | `checkout` | `true` | Set to `false` if the caller has already checked out the tag ref. |
 
 ## Prerequisites
+
+For `pr` to work you need:
+
+- **Allow GitHub Actions to create and approve pull requests** enabled under **Settings → Actions → General → Workflow permissions** (`https://github.com/<user>/<repo>/settings/actions`).
 
 For `publish` to work end to end you need:
 


### PR DESCRIPTION
closes #11 

Updates the documentation to call out that there is a config step which is needed to allow the creation of PRs from actions, which the `pr` job will require. 

I think this is default off for new repos? Not sure tbh, but I don't think I ever touched it in my test repo besides to unblock this action. `¯\_(ツ)_/¯`

## an aside

To be clear, I dont really know the full implication of toggling this! It is the clear unblock to get this action to work, but does represent relaxing permissions within your CI environment. The config says:
> Choose whether GitHub Actions can create pull requests or submit approving pull request reviews.

This documentation is important to unblock people who want to use it, but it may be worth slowing down here and asking what this setting meaningfully changes about someone's threat model in CI. If someone more knowledgeable than me was to audit this action, I'd like them to weigh in on the toggle. 

For folks who already do this, fine, nbd. But I could see how this could be a footgun, although I am not knowledgeable enough to game it out beyond "well, now an action can open/approve a PR if it gets pwned...". It may not be a big deal, but food for thought.