### PR TITLE
feat: handle `0.x.y` versions

### DIFF
--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -177,15 +177,18 @@ export function incVersion (version: string, bump: 'major' | 'minor' | 'patch'):
       `Cannot bump version "${version}": expected strict "X.Y.Z" semver. uppt does not currently support prerelease or build-metadata versions.`,
     )
   }
-  let [, major, minor, patch] = match.map(Number) as [number, number, number, number, number]
-  if (major === 0) {
-    if (bump === 'major') { minor += 1; patch = 0 }
-    else { patch += 1 }
+
+  let [, x, y, z] = match.map(Number) as [number, number, number, number, number]
+
+  if (x === 0) {
+    if (bump === 'major') { bump = 'minor' }
+    else if (bump === 'minor') { bump = 'patch' }
   }
-  else if (bump === 'major') { major += 1; minor = 0; patch = 0 }
-  else if (bump === 'minor') { minor += 1; patch = 0 }
-  else { patch += 1 }
-  return `${major}.${minor}.${patch}`
+
+  if (bump === 'major') { x += 1; y = 0; z = 0 }
+  else if (bump === 'minor') { y += 1; z = 0 }
+  else { z += 1 }
+  return `${x}.${y}.${z}`
 }
 
 function formatChangelog (

--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -178,7 +178,11 @@ export function incVersion (version: string, bump: 'major' | 'minor' | 'patch'):
     )
   }
   let [, major, minor, patch] = match.map(Number) as [number, number, number, number, number]
-  if (bump === 'major') { major += 1; minor = 0; patch = 0 }
+  if (major === 0) {
+    if (bump === 'major') { minor += 1; patch = 0 }
+    else { patch += 1 }
+  }
+  else if (bump === 'major') { major += 1; minor = 0; patch = 0 }
   else if (bump === 'minor') { minor += 1; patch = 0 }
   else { patch += 1 }
   return `${major}.${minor}.${patch}`

--- a/test/update-changelog.test.ts
+++ b/test/update-changelog.test.ts
@@ -35,6 +35,21 @@ describe('incVersion', () => {
     expect(incVersion('1.2.3', 'major')).toBe('2.0.0')
   })
 
+  it('maps a major bump in 0.x.y to the minor slot', () => {
+    expect(incVersion('0.2.3', 'major')).toBe('0.3.0')
+  })
+
+  it('maps minor and patch bumps in 0.x.y to the patch slot', () => {
+    expect(incVersion('0.2.3', 'minor')).toBe('0.2.4')
+    expect(incVersion('0.2.3', 'patch')).toBe('0.2.4')
+  })
+
+  it('supports 0.0.x versions with the same 0.x.y mapping', () => {
+    expect(incVersion('0.0.3', 'major')).toBe('0.1.0')
+    expect(incVersion('0.0.3', 'minor')).toBe('0.0.4')
+    expect(incVersion('0.0.3', 'patch')).toBe('0.0.4')
+  })
+
   it('throws on a prerelease version', () => {
     expect(() => incVersion('1.2.3-rc.1', 'patch')).toThrowError(/strict "X\.Y\.Z" semver/)
   })


### PR DESCRIPTION
Resolve #33 

Behavior:
- `0.x.y`: `0.major.[minor|patch]`
- `0.0.x`: `0.major.[minor|patch]`

Referece: [changelogen:src/semver.ts#L53](https://github.com/unjs/changelogen/blob/172158894cde37fd167c23af91ef8c762aded1e9/src/semver.ts#L53)
